### PR TITLE
Changing attachmentType to contentType according to Azure documentati…

### DIFF
--- a/django_azure_communication_email/backend.py
+++ b/django_azure_communication_email/backend.py
@@ -145,6 +145,6 @@ class ACEmailBackend(BaseEmailBackend):
         converter = attachment.get_converter(file)
         return {
             'name': converter.get_filename(),
-            'attachmentType': converter.get_filetype(),
+            'contentType': converter.get_filetype(),
             'contentInBase64': converter.get_content(),
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-azure-communication-email"
-version = "1.2.0"
+version = "1.2.1"
 description = "A Django email backend for Azure Communication Email service."
 authors = ["Dmitrii Azarenko <dmitrii.azarenko@symphonyai.com>"]
 maintainers = []

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -142,7 +142,7 @@ class TestEmailBackend(TestCase):
             conv_message['attachments'][0],
             {
                 'name': 'file.txt',
-                'attachmentType': 'text/plain',
+                'contentType': 'text/plain',
                 'contentInBase64': base64.b64encode(b'content').decode(),
             },
         )


### PR DESCRIPTION
…on of the email structure for attachments according to 
https://learn.microsoft.com/en-us/azure/communication-services/quickstarts/email/send-email-advanced/send-email-with-attachments?tabs=connection-string&pivots=programming-language-python

````
 "attachments": [
        {
            "contentInBase64": "str",  # Base64 encoded contents of the attachment. Required.
            "contentType": "str",  # MIME type of the content being attached. Required.
            "name": "str"  # Name of the attachment. Required.
        }
    ],
````

Changed also the test in order to get the result